### PR TITLE
Fix for newer versions of scapy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.18
-scipy==1.4.1
-scapy==2.4.3
+numpy==1.26.2
+scipy==1.11.4
+scapy==2.6.1
 requests

--- a/src/cicflowmeter/flow_session.py
+++ b/src/cicflowmeter/flow_session.py
@@ -87,6 +87,68 @@ class FlowSession(DefaultSession):
         if self.packets_count % GARBAGE_COLLECT_PACKETS == 0 or flow.duration > 120:
             self.garbage_collect(pkt.time)
 
+    def process(self, pkt: Packet):
+        """
+        Needed for use in scapy versions above 2.5 because of a breaking change in scapy. 
+        Functionality is same as on_packet_received, but returnvalues are added. 
+        """
+        self.logger.debug(f"Packet {self.packets_count}: {pkt}")
+        count = 0
+        direction = PacketDirection.FORWARD
+
+        if "TCP" not in pkt and "UDP" not in pkt:
+            return pkt  # Return the processed packet
+
+        try:
+            # Creates a key variable to check
+            packet_flow_key = get_packet_flow_key(pkt, direction)
+            flow = self.flows.get((packet_flow_key, count))
+        except Exception:
+            return pkt  # Return the processed packet 
+
+        self.packets_count += 1
+        
+
+        # If there is no forward flow with a count of 0
+        if flow is None:
+            # There might be one of it in reverse
+            direction = PacketDirection.REVERSE
+            packet_flow_key = get_packet_flow_key(pkt, direction)
+            flow = self.flows.get((packet_flow_key, count))
+
+        if flow is None:
+            # If no flow exists create a new flow
+            direction = PacketDirection.FORWARD
+            flow = Flow(pkt, direction)
+            packet_flow_key = get_packet_flow_key(pkt, direction)
+            self.flows[(packet_flow_key, count)] = flow
+
+        elif (pkt.time - flow.latest_timestamp) > EXPIRED_UPDATE:
+            # If the packet exists in the flow but the packet is sent
+            # after too much of a delay than it is a part of a new flow.
+            expired = EXPIRED_UPDATE
+            while (pkt.time - flow.latest_timestamp) > expired:
+                count += 1
+                expired += EXPIRED_UPDATE
+                flow = self.flows.get((packet_flow_key, count))
+
+                if flow is None:
+                    flow = Flow(pkt, direction)
+                    self.flows[(packet_flow_key, count)] = flow
+                    break
+        elif "F" in pkt.flags:
+            # If it has FIN flag then early collect flow and continue
+            flow.add_packet(pkt, direction)
+            self.garbage_collect(pkt.time)
+            return None # Return None to indicate processing is incomplete
+
+        flow.add_packet(pkt, direction)
+
+        if self.packets_count % GARBAGE_COLLECT_PACKETS == 0 or flow.duration > 120:
+            self.garbage_collect(pkt.time)
+        
+        return pkt  # Return the processed packet
+
     def get_flows(self):
         return self.flows.values()
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -85,7 +85,7 @@ def test_features(mock_flow_data):
         "psh_flag_cnt",
         "ack_flag_cnt",
         "urg_flag_cnt",
-        "cwe_flag_count",
+        "cwr_flag_count",
         "ece_flag_cnt",
         "down_up_ratio",
         "pkt_size_avg",


### PR DESCRIPTION
As discussed [here](https://github.com/hieulw/cicflowmeter/issues/12), cicflowmeter is no longer working with scapy versions above 2.5. To fix it I renamed the on_packet_received() function to process() and added respective returnvalues. To keep backwardscompatibility I kept the original function in place. Some distributions may be using older versions of scapy and it doesn't hurt to keep it in place. 