### PR TITLE
fix: correct parameter order in create_sniffer() call

### DIFF
--- a/src/cicflowmeter/sniffer.py
+++ b/src/cicflowmeter/sniffer.py
@@ -185,6 +185,7 @@ def process_directory(input_dir, output_dir, fields=None, verbose=False):
                 input_interface=None,
                 output_mode="csv",
                 output=str(output_file),
+                input_directory=None,
                 fields=fields,
                 verbose=verbose,
             )
@@ -293,12 +294,13 @@ def main():
         return
 
     sniffer, session = create_sniffer(
-        args.input_file,
-        args.input_interface,
-        args.output_mode,
-        args.output,
-        args.fields,
-        args.verbose,
+        input_file=args.input_file,
+        input_interface=args.input_interface,
+        output_mode=args.output_mode,
+        output=args.output,
+        input_directory=None,
+        fields=args.fields,
+        verbose=args.verbose,
     )
     sniffer.start()
 


### PR DESCRIPTION
```
(cicflowmeter) base@LAPTOP-409T8FMM:~/cicflowmeter$ cicflowmeter -f capture.pcap -c flows.csv
Traceback (most recent call last):
  File "/home/base/cicflowmeter/.venv/bin/cicflowmeter", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/base/cicflowmeter/src/cicflowmeter/sniffer.py", line 295, in main
    sniffer, session = create_sniffer(
                       ^^^^^^^^^^^^^^^
  File "/home/base/cicflowmeter/src/cicflowmeter/sniffer.py", line 40, in create_sniffer
    fields = fields.split(",")
             ^^^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'split'
```
When the input_directory parameter was added to create_sniffer(), the
call in main() was not updated to use keyword arguments. This caused
positional argument misalignment where fields and verbose were passed
to the wrong parameters.
