### PR TITLE
prevent ValueError in get_min_forward_header_bytes

### DIFF
--- a/src/cicflowmeter/features/flow_bytes.py
+++ b/src/cicflowmeter/features/flow_bytes.py
@@ -170,9 +170,10 @@ class FlowBytes:
             return 0
 
         return min(
-            self._header_size(packet)
+            (self._header_size(packet)
             for packet, direction in self.flow.packets
-            if direction == PacketDirection.FORWARD
+            if direction == PacketDirection.FORWARD),
+            default=0
         )
 
     def get_reverse_rate(self) -> int:


### PR DESCRIPTION
This PR fixes a crash in `flow_bytes.py` that occurs when a captured flow contains only reverse packets. In such cases, the generator for forward header bytes is empty, causing `min()` to raise a `ValueError`.

### Changes
* **get_min_forward_header_bytes**: Added the `default=0` parameter to the `min()` function. 
* This ensures that if no forward packets are found in a flow, the method returns `0` instead of raising `ValueError: min() arg is an empty sequence`.

### Related Issues
Fixes [#21](https://github.com/hieulw/cicflowmeter/issues/21#issue-3460917939). I have also encountered this crash while processing unidirectional UDP traffic; this PR provides the `default=0` fix as suggested in the open issue.

### Testing
Verified with a unidirectional UDP PCAP. The tool now correctly reports 0 for forward header bytes and continues processing without interruption.